### PR TITLE
Add tmux command arg options

### DIFF
--- a/plugin/tmux-complete.vim
+++ b/plugin/tmux-complete.vim
@@ -11,6 +11,8 @@ function! CompleteScript(findstart, base)
 
     " find months matching with "a:base"
     let command = 'sh ' . shellescape(expand(s:script)) . ' ' . shellescape('^' . escape(a:base, '*^$][.\') . '.')
+    let command .= ' ' . shellescape(get(g:, 'tmux_complete_list_args', '-a'))
+    let command .= ' ' . shellescape(get(g:, 'tmux_complete_capture_args', '-J'))
     let words = system(command)
     for word in split(words)
         call complete_add(word)

--- a/sh/tmuxwords.sh
+++ b/sh/tmuxwords.sh
@@ -12,13 +12,13 @@ if [[ -z "$TMUX_PANE" ]]; then
 fi
 
 # list all panes
-tmux list-panes -a -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
+tmux list-panes $2 -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
 # filter out current pane (use -F to match $ in session id)
 grep -v -F "$(tmux display-message -p '11-#{session_id} ')" |
 # take the pane id
 cut -d' ' -f2 |
 # capture panes
-xargs -n1 tmux capture-pane -J -p -t |
+xargs -n1 tmux capture-pane $3 -p -t |
 # copy lines and split words
 sed -e 'p;s/[^a-zA-Z0-9_]/ /g' |
 # split on spaces


### PR DESCRIPTION
This adds options to modify the `tmux` commands.

Defaults:

`let g:tmux_complete_list_args = '-a'`
Additional args for `tmux list-panes`.

`let g:tmux_complete_capture_args = '-J'`
Additional args for `tmux capture-pane`.

Examples:

`let g:tmux_complete_list_args = '-s'`
Only capture panes of active session.

`let g:tmux_complete_list_args = ''`
Only capture panes of active window.

`let g:tmux_complete_capture_args = '-J -S -1024'`
Join wrapped words and capture up to 1024 lines of scrollback.
