### PR TITLE
Fix shell script path detection and check shell script error

### DIFF
--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -15,5 +15,9 @@ function! tmuxcomplete#completions(base, capture_args)
     let command .=   ' ' . shellescape(a:capture_args)
 
     let completions = system(command)
-    return split(completions)
+    if v:shell_error == 0
+        return split(completions)
+    else
+        return []
+    endif
 endfunction


### PR DESCRIPTION
This fixes use of `<spath>`, which does not return a file path when used inside a function.

What should happen when the script fails? Right now it just returns an empty list.
