### PR TITLE
Use POSIX compliant single brackets in sh/tmuxwords.sh

### DIFF
--- a/sh/tmuxwords.sh
+++ b/sh/tmuxwords.sh
@@ -6,7 +6,7 @@
 # Get all visible words beginning with `foo`:
 #     sh panewords.sh foo
 
-if [[ -z "$TMUX_PANE" ]]; then
+if [ -z "$TMUX_PANE" ]; then
     echo "Not running inside tmux!" 1>&2
     exit 1
 fi


### PR DESCRIPTION
As mentioned in https://github.com/wellle/tmux-complete.vim/issues/23#issuecomment-38186356: `[[` might cause problems in some shells.
