### PR TITLE
unite.vim source

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ completion.
 
 This is automatically integrated with [neocomplete](https://github.com/Shougo/neocomplete.vim).
 
+If you have [unite.vim](https://github.com/Shougo/unite.vim) installed,
+you can use tmuxcomplete as a unite *source*:
+
+    :Unite tmuxcomplete
+
+
 ![][example]
 
 [example]: https://raw.githubusercontent.com/wellle/images/master/tmux-complete-example.png

--- a/autoload/unite/sources/tmuxcomplete.vim
+++ b/autoload/unite/sources/tmuxcomplete.vim
@@ -1,0 +1,34 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! unite#sources#tmuxcomplete#define()
+  return s:s
+endfunction
+
+" define the tmuxcomplete source
+let s:s = {
+      \ 'name' : 'tmuxcomplete',
+      \ 'description' : 'strings from tmux sessions',
+      \ 'hooks' : {},
+      \ 'max_candidates' : 0,
+      \ 'default_kind' : 'word',
+      \ 'sorters' : 'sorter_rank',
+      \ 'default_action' : 'insert',
+      \ 'source__maxstrings' : 0,
+      \ }
+
+" function! s:s.hooks.on_init(args, context) 
+"   call unite#print_source_message('tmux content', s:s.name)
+" endfunction
+
+" provides the results for unite to search/filter/sort.
+function! s:s.gather_candidates(args, context) 
+  return map(tmuxcomplete#words(s:s.source__maxstrings), "{
+        \ 'word' : v:val,
+        \ 'is_multiline' : 0,
+        \ 'action__text' : v:val,
+        \ }")
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This doesn't adversely affect users who don't have unite, because it will never be loaded for them. For those that do have unite, they get:

```
:Unite tmuxcomplete
```

And then you can get strings from tmux even if something like YCM clobbers your `<c-x><c-u>`. 

If you plan to merge this, I will add brief documentation and clean up the commit message, etc.
