### PR TITLE
support tmux 1.6

### DIFF
--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -1,5 +1,9 @@
+call system('tmux list-panes -J &> /dev/null')
+let s:tmux_has_J_option = (v:shell_error == 0)
+
 function! tmuxcomplete#words(scrollback)
-    let capture_args = get(g:, 'tmuxcomplete#capture_args', '-J')
+    let capture_args = get(g:, 'tmuxcomplete#capture_args',
+          \ (s:tmux_has_J_option ? '-J' : ''))
     let capture_args .= ' -S -' . a:scrollback
     return tmuxcomplete#completions('', capture_args)
 endfunction
@@ -34,7 +38,8 @@ function! tmuxcomplete#complete(findstart, base)
         endif
     endif
     " find words matching with "a:base"
-    let capture_args = get(g:, 'tmuxcomplete#capture_args', '-J')
+    let capture_args = get(g:, 'tmuxcomplete#capture_args',
+          \ (s:tmux_has_J_option ? '-J' : ''))
     return tmuxcomplete#completions(a:base, capture_args)
 endfun
 

--- a/sh/tmuxwords.sh
+++ b/sh/tmuxwords.sh
@@ -17,8 +17,8 @@ tmux list-panes $2 -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' 
 grep -v -F "$(tmux display-message -p '11-#{session_id} ')" |
 # take the pane id
 cut -d' ' -f2 |
-# capture panes
-xargs -n1 tmux capture-pane $3 -p -t |
+# capture panes: tmux 1.6+: capture to paste-buffer, echo it, then delete it.
+xargs -n1 -I{} sh -c 'tmux capture-pane $3 -t {} && tmux show-buffer && tmux delete-buffer' |
 # copy lines and split words
 sed -e 'p;s/[^a-zA-Z0-9_]/ /g' |
 # split on spaces


### PR DESCRIPTION
- Although #32 allow setting `capture_args`, it's awkward for people who use the same vimrc on different tmux versions. tmuxcomplete should default to `-J` only if supported (tmux 1.7+).
- tmux 1.6 `capture-pane` does not support -p (send to stdout). It sends the output to a tmux "buffer". So to work with this, tmuxcomplete can just echo each tmux buffer (and delete them afterwards, to avoid cluttering the user's tmux paste-buffers/history).
