### PR TITLE
tmux 1.6: fix capture-pane test

### DIFF
--- a/sh/tmuxwords.sh
+++ b/sh/tmuxwords.sh
@@ -12,7 +12,7 @@ if [ -z "$TMUX_PANE" ]; then
 fi
 
 capturepane() {
-    if tmux capture-pane -p &> /dev/null; then
+    if [ tmux capture-pane -p &> /dev/null ]; then
         # tmux capture-pane understands -p -> use it
         xargs -n1 tmux capture-pane $1 -p -t
     else


### PR DESCRIPTION
I'm back on a machine with tmux 1.6. With the current master, the script just outputs the error message:

```
$ sh sh/tmuxwords.sh
tmux: unknown option -- p
usage: capture-pane [-b buffer-index] [-E end-line] [-S start-line] [-t target-pane]
```

That's odd, because the following command shows no output:

```
$ if tmux capture-pane -p &> /dev/null; then echo 'hi' ; fi
```

Maybe a bash quirk I'm not aware of.

The issue is avoided by wrapping the condition in `[[ ]]`.
