### PR TITLE
54 Proper shell script arguments, include current pane

### DIFF
--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -24,6 +24,7 @@ function! tmuxcomplete#completions(base, capture_args, splitmode)
     let command .= ' -l ' . shellescape(list_args)
     let command .= ' -c ' . shellescape(a:capture_args)
     let command .= ' -g ' . shellescape(grep_args)
+    let command .= ' -e'
 
     let completions = system(command)
     if v:shell_error != 0

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -6,24 +6,24 @@ function! tmuxcomplete#init()
     endif
 endfunction
 
-function! tmuxcomplete#list(mode, scrollback)
+function! tmuxcomplete#list(splitmode, scrollback)
     let capture_args = s:capture_args . ' -S -' . a:scrollback
-    return tmuxcomplete#completions('', capture_args, a:mode)
+    return tmuxcomplete#completions('', capture_args, a:splitmode)
 endfunction
 
 let s:script = expand('<sfile>:h:h') . "/sh/tmuxcomplete"
 
-function! tmuxcomplete#completions(base, capture_args, mode)
-    let base_pattern = '^' . escape(a:base, '*^$][.\') . '.'
-    let list_args    = get(g:, 'tmuxcomplete#list_args', '-a')
-    let grep_args    = tmuxcomplete#grepargs(a:base)
+function! tmuxcomplete#completions(base, capture_args, splitmode)
+    let pattern   = '^' . escape(a:base, '*^$][.\') . '.'
+    let list_args = get(g:, 'tmuxcomplete#list_args', '-a')
+    let grep_args = tmuxcomplete#grepargs(a:base)
 
-    let command  = 'sh ' . shellescape(s:script)
-    let command .=   ' ' . shellescape(a:mode)
-    let command .=   ' ' . shellescape(base_pattern)
-    let command .=   ' ' . shellescape(list_args)
-    let command .=   ' ' . shellescape(a:capture_args)
-    let command .=   ' ' . shellescape(grep_args)
+    let command  =  'sh ' . shellescape(s:script)
+    let command .= ' -p ' . shellescape(pattern)
+    let command .= ' -s ' . shellescape(a:splitmode)
+    let command .= ' -l ' . shellescape(list_args)
+    let command .= ' -c ' . shellescape(a:capture_args)
+    let command .= ' -g ' . shellescape(grep_args)
 
     let completions = system(command)
     if v:shell_error != 0

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -52,13 +52,16 @@ esac
 done
 
 capturepane() {
-    if tmux capture-pane -p >/dev/null 2>&1; then
+    panes=$(cat)
+    if [ -z "$panes" ]; then
+        echo 'no panes' 1>&2
+    elif tmux capture-pane -p >/dev/null 2>&1; then
         # tmux capture-pane understands -p -> use it
-        xargs -n1 tmux capture-pane $1 -p -t
+        echo "$panes" | xargs -n1 tmux capture-pane $1 -p -t
     else
         # tmux capture-pane doesn't understand -p (like version 1.6)
         # -> capture to paste-buffer, echo it, then delete it
-        xargs -n1 -I{} sh -c "tmux capture-pane $1 -t {} && tmux show-buffer && tmux delete-buffer"
+        echo "$panes" | xargs -n1 -I{} sh -c "tmux capture-pane $1 -t {} && tmux show-buffer && tmux delete-buffer"
     fi
 }
 
@@ -77,22 +80,16 @@ splitlines() {
 }
 
 # list all panes
-_tmux_panes="$(tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
-    # filter out current pane (use -F to match $ in session id)
-    ( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat ) |
-    # take the pane id
-    cut -d' ' -f2)"
-
-if [ "$_tmux_panes" ]; then
-    echo $_tmux_panes |
-    # capture panes
-    capturepane "$CAPTUREARGS" |
-    # split words or lines depending on splitmode
-    ( [ "$SPLITMODE" = "lines" ] && splitlines || splitwords ) |
-    # filter out words not matching pattern
-    grep -e "$PATTERN" $GREPARGS |
-    # sort and remove duplicates
-    sort -u
-fi
-
-unset _tmux_panes
+tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
+# filter out current pane (use -F to match $ in session id)
+( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat ) |
+# take the pane id
+cut -d' ' -f2 |
+# capture panes
+capturepane "$CAPTUREARGS" |
+# split words or lines depending on splitmode
+( [ "$SPLITMODE" = "lines" ] && splitlines || splitwords ) |
+# filter out words not matching pattern
+grep -e "$PATTERN" $GREPARGS |
+# sort and remove duplicates
+sort -u

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -1,19 +1,28 @@
 #!/bin/sh
 
-# Usage: Get a list of all currently visible words:
-#     sh tmuxcomplete -s words -p '' -l '-a'
+# Usage: Get a list of all words visible in current window excluding current pane
+#     sh tmuxcomplete
 #
-# Get all visible words beginning with `foo`:
-#     sh tmuxcomplete -s words -p '^foo' -l '-a'
+# Words visible in current session, excluding current pane
+#     sh tmuxcomplete -l '-s'
 #
-# Get all visible words beginning with `foo`, ignoring case:
-#     sh tmuxcomplete -s words -p '^foo' -l '-a' -c '' -g '-i'
+# Words visible in all sessions, excluding current pane
+#     sh tmuxcomplete -l '-a'
 #
-# Get all visible lines beginning with `foo`:
-#     sh tmuxcomplete -s lines -p '^foo' -l '-a'
+# Words containing 'foo'
+#     sh tmuxcomplete -p 'foo'
 #
-# Get a list of all words, including 2000 lines from the history:
-#     sh tmuxcomplete -s words -p '' -l '-a' -c '-S -2000'
+# List of lines
+#     sh tmuxcomplete -s lines
+#
+# Words containing 'foo', ignoring case
+#     sh tmuxcomplete -p 'foo' -g '-i'
+#
+# Words beginning with 'foo'
+#     sh tmuxcomplete -p '^foo'
+#
+# Words including 2000 lines of history per pane
+#     sh tmuxcomplete -c '-S -2000'
 
 if [ -z "$TMUX_PANE" ]; then
     echo "Not running inside tmux!" 1>&2

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -51,7 +51,19 @@ do case $name in
 esac
 done
 
-capturepane() {
+listpanes() {
+    tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}'
+}
+
+excludecurrent() {
+    ( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat )
+}
+
+paneids() {
+    cut -d' ' -f2
+}
+
+capturepanes() {
     panes=$(cat)
     if [ -z "$panes" ]; then
         echo 'no panes' 1>&2
@@ -65,6 +77,19 @@ capturepane() {
     fi
 }
 
+split() {
+    if [ "$SPLITMODE" = "lines" ]; then
+        splitlines
+    else
+        splitwords
+    fi
+}
+
+splitlines() {
+    # remove surrounding whitespace
+    grep -o "\\S.*\\S"
+}
+
 splitwords() {
     # copy lines and split words
     sed -e 'p;s/[^a-zA-Z0-9_]/ /g' |
@@ -74,21 +99,16 @@ splitwords() {
     grep -o "\\w.*\\w"
 }
 
-splitlines() {
-    # remove surrounding whitespace
-    grep -o "\\S.*\\S"
-}
-
 # list all panes
-tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
+listpanes |
 # filter out current pane (use -F to match $ in session id)
-( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat ) |
+excludecurrent |
 # take the pane id
-cut -d' ' -f2 |
+paneids |
 # capture panes
-capturepane "$CAPTUREARGS" |
+capturepanes "$CAPTUREARGS" |
 # split words or lines depending on splitmode
-( [ "$SPLITMODE" = "lines" ] && splitlines || splitwords ) |
+split |
 # filter out words not matching pattern
 grep -e "$PATTERN" $GREPARGS |
 # sort and remove duplicates

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -1,26 +1,41 @@
 #!/bin/sh
 
 # Usage: Get a list of all currently visible words:
-#     sh tmuxcomplete words '' -a
+#     sh tmuxcomplete -s words -p '' -l '-a'
 #
 # Get all visible words beginning with `foo`:
-#     sh tmuxcomplete words '^foo' -a
+#     sh tmuxcomplete -s words -p '^foo' -l '-a'
 #
 # Get all visible words beginning with `foo`, ignoring case:
-#     sh tmuxcomplete words '^foo' -a '' -i
+#     sh tmuxcomplete -s words -p '^foo' -l '-a' -c '' -g '-i'
 #
 # Get all visible lines beginning with `foo`:
-#     sh tmuxcomplete lines '^foo' -a
+#     sh tmuxcomplete -s lines -p '^foo' -l '-a'
 #
 # Get a list of all words, including 2000 lines from the history:
-#     sh tmuxcomplete words '' -a '-S -2000'
+#     sh tmuxcomplete -s words -p '' -l '-a' -c '-S -2000'
 
 if [ -z "$TMUX_PANE" ]; then
     echo "Not running inside tmux!" 1>&2
     exit 1
 fi
 
-MODE="$1" PATTERN="$2" LISTARGS="$3" CAPTUREARGS="$4" GREPARGS="$5"
+PATTERN=''
+SPLITMODE=words
+LISTARGS=''
+CAPTUREARGS=''
+GREPARGS=''
+while getopts p:s:l:c:g: name
+do case $name in
+    p) PATTERN="$OPTARG";;
+    s) SPLITMODE="$OPTARG";;
+    l) LISTARGS="$OPTARG";;
+    c) CAPTUREARGS="$OPTARG";;
+    g) GREPARGS="$OPTARG";;
+    *) echo "Usage: $0 [-p pattern] [-s splitmode] [-l listargs] [-c captureargs] [-g grepargs]\n"
+        exit 2;;
+esac
+done
 
 capturepane() {
     if tmux capture-pane -p >/dev/null 2>&1; then
@@ -58,8 +73,8 @@ if [ "$_tmux_panes" ]; then
     echo $_tmux_panes |
     # capture panes
     capturepane "$CAPTUREARGS" |
-    # split words or lines depending on mode
-    ( [ "$MODE" = "lines" ] && splitlines || splitwords ) |
+    # split words or lines depending on splitmode
+    ( [ "$SPLITMODE" = "lines" ] && splitlines || splitwords ) |
     # filter out words not matching pattern
     grep -e "$PATTERN" $GREPARGS |
     # sort and remove duplicates

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -69,11 +69,11 @@ capturepanes() {
         echo 'no panes' 1>&2
     elif tmux capture-pane -p >/dev/null 2>&1; then
         # tmux capture-pane understands -p -> use it
-        echo "$panes" | xargs -n1 tmux capture-pane $1 -p -t
+        echo "$panes" | xargs -n1 tmux capture-pane $CAPTUREARGS -p -t
     else
         # tmux capture-pane doesn't understand -p (like version 1.6)
         # -> capture to paste-buffer, echo it, then delete it
-        echo "$panes" | xargs -n1 -I{} sh -c "tmux capture-pane $1 -t {} && tmux show-buffer && tmux delete-buffer"
+        echo "$panes" | xargs -n1 -I{} sh -c "tmux capture-pane $CAPTUREARGS -t {} && tmux show-buffer && tmux delete-buffer"
     fi
 }
 
@@ -106,7 +106,7 @@ excludecurrent |
 # take the pane id
 paneids |
 # capture panes
-capturepanes "$CAPTUREARGS" |
+capturepanes |
 # split words or lines depending on splitmode
 split |
 # filter out words not matching pattern

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -56,7 +56,14 @@ listpanes() {
 }
 
 excludecurrent() {
-    ( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat )
+    if [ "$EXCLUDE" = "1" ]; then
+        currentpane=$(tmux display-message -p '11-#{session_id} ')
+        # echo 1>&2 'current' "$currentpane"
+        # use -F to match $ in session id
+        grep -v -F "$currentpane"
+    else
+        cat
+    fi
 }
 
 paneids() {
@@ -66,7 +73,7 @@ paneids() {
 capturepanes() {
     panes=$(cat)
     if [ -z "$panes" ]; then
-        echo 'no panes' 1>&2
+        # echo 'no panes' 1>&2
     elif tmux capture-pane -p >/dev/null 2>&1; then
         # tmux capture-pane understands -p -> use it
         echo "$panes" | xargs -n1 tmux capture-pane $CAPTUREARGS -p -t
@@ -101,7 +108,7 @@ splitwords() {
 
 # list all panes
 listpanes |
-# filter out current pane (use -F to match $ in session id)
+# filter out current pane
 excludecurrent |
 # take the pane id
 paneids |
@@ -109,7 +116,7 @@ paneids |
 capturepanes |
 # split words or lines depending on splitmode
 split |
-# filter out words not matching pattern
+# filter out items not matching pattern
 grep -e "$PATTERN" $GREPARGS |
 # sort and remove duplicates
 sort -u

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -1,12 +1,15 @@
 #!/bin/sh
 
-# Usage: Get a list of all words visible in current window excluding current pane
+# Usage: Get a list of all words visible in current window
 #     sh tmuxcomplete
 #
-# Words visible in current session, excluding current pane
+# Words visible in current window, excluding current pane
+#     sh tmuxcomplete -e
+#
+# Words visible in current session
 #     sh tmuxcomplete -l '-s'
 #
-# Words visible in all sessions, excluding current pane
+# Words visible in all sessions
 #     sh tmuxcomplete -l '-a'
 #
 # Words containing 'foo'
@@ -29,13 +32,15 @@ if [ -z "$TMUX_PANE" ]; then
     exit 1
 fi
 
+EXCLUDE='0'
 PATTERN=''
 SPLITMODE=words
 LISTARGS=''
 CAPTUREARGS=''
 GREPARGS=''
-while getopts p:s:l:c:g: name
+while getopts ep:s:l:c:g: name
 do case $name in
+    e) EXCLUDE="1";;
     p) PATTERN="$OPTARG";;
     s) SPLITMODE="$OPTARG";;
     l) LISTARGS="$OPTARG";;
@@ -74,7 +79,7 @@ splitlines() {
 # list all panes
 _tmux_panes="$(tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}' |
     # filter out current pane (use -F to match $ in session id)
-    grep -v -F "$(tmux display-message -p '11-#{session_id} ')" |
+    ( [ "$EXCLUDE" = "1" ] && grep -v -F "$(tmux display-message -p '11-#{session_id} ')" || cat ) |
     # take the pane id
     cut -d' ' -f2)"
 


### PR DESCRIPTION
Close #54.

Use proper arguments instead of relying on order.
Include current pane by default, add option `-e` to exclude it (used for Vim completion).

@blueyed: I restructured the script a bit again. Let me know what you think. I also removed the `unset`. Is there a particular reason why you added it?