### PR TITLE
sh: fix "remove surrounding non-word characters"

### DIFF
--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -104,7 +104,7 @@ splitwords() {
     # split on spaces
     tr -s '[:space:]' '\n' |
     # remove surrounding non-word characters
-    grep -o "\\w.*\\w"
+    grep -o "\w*"
 }
 
 # list all panes


### PR DESCRIPTION
'\w.*\.*' matches 'foo-bar', although only 'foo' and 'bar' should get
matched there.