### PR TITLE
58 Add gvim/MacVim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ completion.
 
 ![][example]
 
+It also completes words that are scrolled off, hidden in background tmux
+windows and even different tmux sessions. And it even works from gvim or
+MacVim!
+
+![][gvim]
+
 [example]: https://raw.githubusercontent.com/wellle/images/master/tmux-complete-example.png
+[gvim]: https://raw.githubusercontent.com/wellle/images/master/gvim-complete.png
 
 ## Third party integration
 

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -24,7 +24,10 @@ function! tmuxcomplete#completions(base, capture_args, splitmode)
     let command .= ' -l ' . shellescape(list_args)
     let command .= ' -c ' . shellescape(a:capture_args)
     let command .= ' -g ' . shellescape(grep_args)
-    let command .= ' -e'
+
+    if $TMUX_PANE !=# ""     " if running inside tmux
+        let command .= ' -e' " exclude current pane
+    endif
 
     let completions = system(command)
     if v:shell_error != 0

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -27,9 +27,10 @@
 # Words including 2000 lines of history per pane
 #     sh tmuxcomplete -c '-S -2000'
 
-if [ -z "$TMUX_PANE" ]; then
-    echo "Not running inside tmux!" 1>&2
-    exit 1
+if ! tmux info &> /dev/null; then
+    echo "[tmux-complete.vim]"
+    echo "No tmux found!"
+    exit 0
 fi
 
 EXCLUDE='0'


### PR DESCRIPTION
Close #58 

Allow completion from gvim/MacVim if tmux is running anywhere.
Consider words from active pane when completing from gvim/MacVim.
Add gvim/MacVim screenshot to Readme:

<img width="986" alt="gvim-complete" src="https://cloud.githubusercontent.com/assets/474504/10776043/56d5c7d0-7d0e-11e5-9938-cc7acecca3f7.png">

@mgraham: Thanks for bringing this to my attention!