### PR TITLE
add neocomplcache integration

### DIFF
--- a/autoload/neocomplcache/sources/tmuxcomplete.vim
+++ b/autoload/neocomplcache/sources/tmuxcomplete.vim
@@ -1,0 +1,22 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:source = {
+            \ 'name' : 'tmux-complete',
+            \ 'kind' : 'keyword',
+            \ 'mark' : '[tmux]',
+            \ 'rank' : 4,
+            \ 'min_pattern_length' :
+            \ g:neocomplcache_auto_completion_start_length,
+            \ }
+
+function! s:source.gather_candidates(context)
+    return tmuxcomplete#complete(0, a:context.complete_str)
+endfunction
+
+function! neocomplcache#sources#tmuxcomplete#define()
+    return s:source
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
Hello,

Thank you for the plugin, I've just installed it and find it useful, however in some systems I'm stuck with old vim versions 7.3-429 (Ubuntu 12.04 LTS)and therefore I use neocomplcache. This commit adds neocomplcache integration.