### PR TITLE
System call should be done in the python process to avoid blocking Neovim

### DIFF
--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -13,7 +13,7 @@ endfunction
 
 let s:script = expand('<sfile>:h:h') . "/sh/tmuxcomplete"
 
-function! tmuxcomplete#completions(base, capture_args, splitmode)
+function! s:build_command(base, capture_args, splitmode)
     let pattern   = '^' . escape(a:base, '*^$][.\') . '.'
     let list_args = get(g:, 'tmuxcomplete#list_args', '-a')
     let grep_args = tmuxcomplete#grepargs(a:base)
@@ -28,6 +28,16 @@ function! tmuxcomplete#completions(base, capture_args, splitmode)
     if $TMUX_PANE !=# ""     " if running inside tmux
         let command .= ' -e' " exclude current pane
     endif
+
+    return command
+endfunction
+
+function! tmuxcomplete#getcommand(base, splitmode)
+    return s:build_command(a:base, s:capture_args, a:splitmode)
+endfunction
+
+function! tmuxcomplete#completions(base, capture_args, splitmode)
+    let command = s:build_command(a:base, a:capture_args, a:splitmode)
 
     let completions = system(command)
     if v:shell_error != 0

--- a/rplugin/python3/deoplete/sources/tmuxcomplete.py
+++ b/rplugin/python3/deoplete/sources/tmuxcomplete.py
@@ -1,6 +1,7 @@
 from .base import Base
 
 import deoplete.util
+from subprocess import check_output
 
 class Source(Base):
     def __init__(self, vim):
@@ -12,5 +13,6 @@ class Source(Base):
         self.rank = 4
 
     def gather_candidates(self, context):
-        return [{ 'word': x } for x in
-                self.vim.call('tmuxcomplete#gather_candidates')]
+        command = self.vim.call('tmuxcomplete#getcommand', '', 'words')
+        words = check_output(['sh', '-c', command]).decode('utf-8').splitlines()
+        return [{ 'word': x } for x in words]


### PR DESCRIPTION
This PR replaces the Vim system call for one directly in Python. This is important because `vim#call` end up blocking vim instance. It becomes a problem if the person has a higher limit of words to be used during completion, as Vim starts to freeze while typing. This pull request fixes that.
