### PR TITLE
Add integration with ncm2

### DIFF
--- a/autoload/ncm2_tmux_complete.vim
+++ b/autoload/ncm2_tmux_complete.vim
@@ -1,0 +1,37 @@
+if get(s:, 'loaded', 0)
+    finish
+endif
+let s:loaded = 1
+
+let g:ncm2_tmux_complete_enabled = get(g:, 'ncm2_tmux_complete_enabled',  1)
+
+let g:ncm2_tmux_complete#proc = yarp#py3('ncm2_tmux_complete')
+
+let g:ncm2_tmux_complete#source = get(g:, 'ncm2_tmux_complete#source', {
+            \ 'name': 'tmux',
+            \ 'priority': 4,
+            \ 'mark': 'tmux',
+            \ 'on_complete': 'ncm2_tmux_complete#on_complete',
+            \ 'on_warmup': 'ncm2_tmux_complete#on_warmup'
+            \ })
+
+let g:ncm2_tmux_complete#source = extend(g:ncm2_tmux_complete#source,
+            \ get(g:, 'ncm2_tmux_complete#source_override', {}),
+            \ 'force')
+
+function! ncm2_tmux_complete#init()
+    call ncm2#register_source(g:ncm2_tmux_complete#source)
+endfunction
+
+function! ncm2_tmux_complete#on_warmup(ctx)
+    call g:ncm2_tmux_complete#proc.jobstart()
+endfunction
+
+function! ncm2_tmux_complete#on_complete(ctx)
+    let s:is_enabled = get(b:, 'ncm2_tmux_complete_enabled',
+                \ get(g:, 'ncm2_tmux_complete_enabled', 1))
+    if ! s:is_enabled
+        return
+    endif
+    call g:ncm2_tmux_complete#proc.try_notify('on_complete', a:ctx)
+endfunction

--- a/ncm2-plugin/ncm2_tmux_complete.vim
+++ b/ncm2-plugin/ncm2_tmux_complete.vim
@@ -1,0 +1,1 @@
+call ncm2_tmux_complete#init()

--- a/pythonx/ncm2_tmux_complete.py
+++ b/pythonx/ncm2_tmux_complete.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import vim
+from ncm2 import Ncm2Source, getLogger
+from subprocess import check_output
+
+
+logger = getLogger(__name__)
+
+
+class Source(Ncm2Source):
+    def __init__(self, nvim):
+        super(Source, self).__init__(nvim)
+
+    def on_complete(self, ctx):
+
+        command = vim.call('tmuxcomplete#getcommand', '', 'words')
+        words = check_output(['sh', '-c', command]
+                             ).decode('utf-8').splitlines()
+        matches = [{'word': x} for x in words]
+        self.complete(ctx, ctx['startccol'], matches)
+
+
+source = Source(vim)
+
+on_complete = source.on_complete


### PR DESCRIPTION
As I'm not any good at vimscript, the implementation is fully borrowed from ncm2-look and the existing Deoplete source. I've been using it for over a week now and it's been working fine so far.

Also I'm not sure that this location is the best for that file `autoload/ncm2_tmux_complete.vim`. I tried putting that vim file into a subfolder, similar to `unite` and others, but it wouldn't autoload in that case.