### PR TITLE
84 Add async support for coc.nvim

### DIFF
--- a/autoload/coc/source/tmuxcomplete.vim
+++ b/autoload/coc/source/tmuxcomplete.vim
@@ -1,19 +1,19 @@
 function! coc#source#tmuxcomplete#init() abort
-  return {
-        \ 'priority': 1,
-        \ 'shortcut': 'TMUX',
-        \}
+    return {
+                \ 'priority': 1,
+                \ 'shortcut': 'TMUX',
+                \ }
 endfunction
 
-function! coc#source#tmuxcomplete#complete(opt, cb) abort
-  let items = tmuxcomplete#gather_candidates()
-  call a:cb(s:ListToDict(items))
+function! coc#source#tmuxcomplete#complete(opt, callback) abort
+    let Callback = function('s:ListToDict', [a:callback]) " wrap callback
+    call tmuxcomplete#async#gather_candidates(Callback)
 endfunction
 
-function! s:ListToDict(items)
-  let res = []
-  for item in a:items
-    call add(res, {'word' : item})
-  endfor
-  return res
+function! s:ListToDict(callback, items)
+    let res = []
+    for item in a:items
+        call add(res, {'word' : item})
+    endfor
+    call a:callback(res)
 endfunction

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -130,7 +130,7 @@ endfunction
 
 " for integration with completion frameworks
 function! tmuxcomplete#gather_candidates()
-    return tmuxcomplete#complete(0, '')
+    return tmuxcomplete#completions('', s:capture_args, 'words')
 endfunction
 
 call tmuxcomplete#init()

--- a/autoload/tmuxcomplete/async.vim
+++ b/autoload/tmuxcomplete/async.vim
@@ -1,0 +1,22 @@
+function! s:on_stdout(job_id, data, event) dict
+    let self.output[-1] .= a:data[0]
+    call extend(self.output, a:data[1:])
+endfunction
+
+function! s:on_exit(job_id, data, event) dict
+    " drop the last (empty) item
+    let candidates = self.output[1 : -2]
+    call self.callback(candidates)
+endfunction
+
+function! tmuxcomplete#async#gather_candidates(callback)
+    let command = tmuxcomplete#getcommandlist('', 10, 'words')
+    let context = {
+                \ 'output':   [''],
+                \ 'callback': a:callback,
+                \ }
+    let job_id = jobstart(command, {
+                \ 'on_stdout': function('s:on_stdout', context),
+                \ 'on_exit':   function('s:on_exit', context),
+                \ })
+endfunction

--- a/autoload/tmuxcomplete/async.vim
+++ b/autoload/tmuxcomplete/async.vim
@@ -1,11 +1,21 @@
-function! s:on_stdout(job_id, data, event) dict
+function! s:on_stdout_nvim(job_id, data, event) dict
     let self.output[-1] .= a:data[0]
     call extend(self.output, a:data[1:])
 endfunction
 
-function! s:on_exit(job_id, data, event) dict
+function! s:on_exit_nvim(job_id, data, event) dict
     " drop the last (empty) item
-    let candidates = self.output[1 : -2]
+    let candidates = self.output[: -2]
+    call self.callback(candidates)
+endfunction
+
+function! s:on_output_vim(channel, message) dict
+    call add(self.output, a:message)
+endfunction
+
+function! s:on_exit_vim(job, status) dict
+    " drop the first (empty) item
+    let candidates = self.output[1 :]
     call self.callback(candidates)
 endfunction
 
@@ -15,8 +25,16 @@ function! tmuxcomplete#async#gather_candidates(callback)
                 \ 'output':   [''],
                 \ 'callback': a:callback,
                 \ }
-    let job_id = jobstart(command, {
-                \ 'on_stdout': function('s:on_stdout', context),
-                \ 'on_exit':   function('s:on_exit', context),
-                \ })
+
+    if has('nvim')
+        call jobstart(command, {
+                    \ 'on_stdout': function('s:on_stdout_nvim', context),
+                    \ 'on_exit':   function('s:on_exit_nvim', context),
+                    \ })
+    else
+        call job_start(command, {
+                    \ 'out_cb':  function('s:on_output_vim', context),
+                    \ 'exit_cb': function('s:on_exit_vim', context),
+                    \ })
+    endif
 endfunction


### PR DESCRIPTION
As reported in https://github.com/wellle/tmux-complete.vim/pull/84#issuecomment-489365681, the coc.nvim integration could block Vim/Neovim if gathering the candidates takes a long time.

This PR uses the respective Vim/Neovim functions to start asynchronous jobs instead.

Tested locally with Neovim 0.3.5 and Vim 8.1.1200.