### PR TITLE
Add Feature: Copy all visible lines in specified tmux pane to buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ There is also a function that copies all the text visible in a particular tmux
 pane directly into a new split buffer in your Vim instance!
 
 Simply call the function, and specify the pane you want:
-![][example_pane_to_buffer_before]
+
+![pane_selection](https://user-images.githubusercontent.com/52209396/148301300-c4b002d6-6362-4e81-b1a0-52277088a51c.jpg)
+
 
 And it's right there, ready to be bent to Vim's will:
-![][example_pane_to_buffer_after]
+
+![pane_2](https://user-images.githubusercontent.com/52209396/148301308-2f8db950-498c-442c-84e4-d354f94dbcec.jpg)
 
 ## Third party integration
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ MacVim!
 There is also a function that copies all the text visible in a particular tmux
 pane directly into a new split buffer in your Vim instance!
 
-Simply call the function, and specify the pane you want:
+Simply call the function, or map it to something:
+
+```
+:call tmuxcomplete#tmux_pane_to_buffer()
+
+nnoremap <LEADER>t :call tmuxcomplete#tmux_pane_to_buffer()<CR>
+```
+
+, and specify the pane you want:
 
 ![pane_selection](https://user-images.githubusercontent.com/52209396/148301300-c4b002d6-6362-4e81-b1a0-52277088a51c.jpg)
 
@@ -223,7 +231,7 @@ behavior, put this in your .vimrc:
     let g:tmuxcomplete_pane_index_display_duration_ms = 0
     ```
 
-- Or set it to a different duration:
+- Or set it to a different duration (as a string):
     
     ```vim
     let g:tmuxcomplete_pane_index_display_duration_ms = "1000"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tmux-complete.vim
 
-Vim plugin for insert mode completion of words in adjacent tmux panes
+Vim plugin for insert mode completion of words in adjacent tmux panes and
+duplicating the contents of a visible tmux pane in a split buffer.
 
 ## Motivation
 
@@ -8,13 +9,18 @@ If you're using Vim in tandem with Tmux you might be familiar with this pesky
 situation:
 
 You're happily editing your lovely files in Vim, when you notice you need to
-type a word that you can see in a different Tmux pane right next to Vim. This
-might be some secret key found in your REPL or the name of a failing test.
+type a word, or a chunk of text, that you can see in a different Tmux pane
+right next to Vim. This might be some secret key found in your REPL or the name
+of a failing test.
 
-Usually the interesting text is too short to warrant switching panes and going
-into Tmux' copy mode, so you end typing it out again.
+Usually the interesting text is too short, to warrant switching panes and going
+into Tmux's copy mode, so you end up typing it out again.
 
-## But fear no longer!
+Or maybe You just don't like using Tmux's copy mode, period. You feel like that
+chunk of text sitting in a distant Tmux pane ought to be just as accessible to
+you as a chunk of text sitting in a Vim buffer.
+
+## Well, fear no longer!
 
 This plugin adds a completion function that puts all words visible in your Tmux
 panes right under your fingertips. Just enter insert mode, start typing any
@@ -31,6 +37,15 @@ MacVim!
 
 [example]: https://raw.githubusercontent.com/wellle/images/master/tmux-complete-example.png
 [gvim]: https://raw.githubusercontent.com/wellle/images/master/gvim-complete.png
+
+There is also a function that copies all the text visible in a particular tmux
+pane directly into a new split buffer in your Vim instance!
+
+Simply call the function, and specify the pane you want:
+![][example_pane_to_buffer_before]
+
+And it's right there, ready to be bent to Vim's will:
+![][example_pane_to_buffer_after]
 
 ## Third party integration
 
@@ -196,3 +211,18 @@ tmux-complete by putting one of these lines into your `.vimrc`:
 
 The trigger function itself is named `tmuxcomplete#complete` (in case you want
 to call it manually).
+
+- When copying the text in a Tmux pane to a Vim buffer, Tmux is instructed to
+briefly flash the pane indexes for 350ms to aid in your choice. To disable this
+behavior, put this in your .vimrc:
+
+    ```vim
+    let g:tmuxcomplete_pane_index_display_duration_ms = 0
+    ```
+
+- Or set it to a different duration:
+    
+    ```vim
+    let g:tmuxcomplete_pane_index_display_duration_ms = "1000"
+    ```
+    

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Simply call the function like so:
 nnoremap <LEADER>t :call tmuxcomplete#tmux_pane_to_buffer()<CR>
 ```
 
-, and specify the pane you want:
+After the function is called, the tmux pane indices are flashed for a brief moment. Then just type the number to specify the pane you want:
 
 ![pane_selection](https://user-images.githubusercontent.com/52209396/148301300-c4b002d6-6362-4e81-b1a0-52277088a51c.jpg)
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Simply call the function like so:
 nnoremap <LEADER>t :call tmuxcomplete#tmux_pane_to_buffer()<CR>
 ```
 
-After the function is called, the tmux pane indices are flashed for a brief moment. Then just type the number to specify the pane you want:
+After the function is called, the tmux pane indices are flashed for a brief moment. Then just type the number to specify the pane you want and hit enter:
 
 ![pane_selection](https://user-images.githubusercontent.com/52209396/148301300-c4b002d6-6362-4e81-b1a0-52277088a51c.jpg)
 
 
-And it's right there, ready to be bent to Vim's will:
+Here I typed '2', ad it's right there, ready to be bent to Vim's will:
 
 ![pane_2](https://user-images.githubusercontent.com/52209396/148301308-2f8db950-498c-442c-84e4-d354f94dbcec.jpg)
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ MacVim!
 There is also a function that copies all the text visible in a particular tmux
 pane directly into a new split buffer in your Vim instance!
 
-Simply call the function, or map it to something:
+Simply call the function like so:
 
-```
+```vim
 :call tmuxcomplete#tmux_pane_to_buffer()
+```
 
+ Or map it to something convienient:
+
+```vim
 nnoremap <LEADER>t :call tmuxcomplete#tmux_pane_to_buffer()<CR>
 ```
 

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -144,7 +144,7 @@ function! tmuxcomplete#tmux_pane_to_buffer()
     let targetpane = input("target_pane:")
     if targetpane =~ '\d\+'
         silent execute 'split .tmux_pane_'.targetpane
-        silent execute '%!sh ~/linux_config_files/bin/tmuxcomplete.sh -t '.targetpane.' -s lines -n'
+        silent execute '%!sh '.s:script.' -t '.targetpane.' -s lines -n'
         set filetype=bash
         setlocal buftype=nofile
         setlocal bufhidden=hide

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -139,7 +139,9 @@ function! tmuxcomplete#display_tmux_pane_indices(duration)
 endfunction                             
 
 function! tmuxcomplete#tmux_pane_to_buffer()
-    call tmuxcomplete#display_tmux_pane_indices("350")
+    if g:tmuxcomplete_pane_index_display_duration_ms > 0
+        call tmuxcomplete#display_tmux_pane_indices(g:tmuxcomplete_pane_index_display_duration_ms)
+    endif
     " get the input from user
     let targetpane = input("target_pane:")
     if targetpane =~ '\d\+'

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -133,13 +133,13 @@ function! tmuxcomplete#gather_candidates()
     return tmuxcomplete#completions('', s:capture_args, 'words')
 endfunction
 
-function! DisplayTmuxPaneIndices(duration)
+function! tmuxcomplete#display_tmux_pane_indices(duration)
     " bring up the pane numbers as a background job
     call job_start(["tmux", "display-pane", "-d", a:duration])
 endfunction                             
 
-function! TmuxPaneToBuffer()
-    call DisplayTmuxPaneIndices("350")
+function! tmuxcomplete#tmux_pane_to_buffer()
+    call tmuxcomplete#display_tmux_pane_indices("350")
     " get the input from user
     let targetpane = input("target_pane:")
     if targetpane =~ '\d\+'
@@ -152,5 +152,3 @@ function! TmuxPaneToBuffer()
         setlocal nobuflisted
     endif
 endfunction                             
-
-call tmuxcomplete#init()

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -133,4 +133,24 @@ function! tmuxcomplete#gather_candidates()
     return tmuxcomplete#completions('', s:capture_args, 'words')
 endfunction
 
+function! DisplayTmuxPaneIndices(duration)
+    " bring up the pane numbers as a background job
+    call job_start(["tmux", "display-pane", "-d", a:duration])
+endfunction                             
+
+function! TmuxPaneToBuffer()
+    call DisplayTmuxPaneIndices("350")
+    " get the input from user
+    let targetpane = input("target_pane:")
+    if targetpane =~ '\d\+'
+        silent execute 'split .tmux_pane_'.targetpane
+        silent execute '%!sh ~/linux_config_files/bin/tmuxcomplete.sh -t '.targetpane.' -s lines -n'
+        set filetype=bash
+        setlocal buftype=nofile
+        setlocal bufhidden=hide
+        setlocal noswapfile
+        setlocal nobuflisted
+    endif
+endfunction                             
+
 call tmuxcomplete#init()

--- a/autoload/tmuxcomplete.vim
+++ b/autoload/tmuxcomplete.vim
@@ -154,3 +154,5 @@ function! tmuxcomplete#tmux_pane_to_buffer()
         setlocal nobuflisted
     endif
 endfunction                             
+
+call tmuxcomplete#init()

--- a/plugin/tmuxcomplete.vim
+++ b/plugin/tmuxcomplete.vim
@@ -25,6 +25,7 @@ function! s:init()
       lua require'compe'.register_source('tmux', require'compe_tmux')
     endif
 
+    " for use with tmuxcomplete#tmux_pane_to_buffer()
     let g:tmuxcomplete_pane_index_display_duration_ms = "350"
 
 endfunction

--- a/plugin/tmuxcomplete.vim
+++ b/plugin/tmuxcomplete.vim
@@ -25,7 +25,7 @@ function! s:init()
       lua require'compe'.register_source('tmux', require'compe_tmux')
     endif
 
-    if exists('g:tmuxcomplete_pane_index_display_duration_ms')
+    if !exists('g:tmuxcomplete_pane_index_display_duration_ms')
         " for use with tmuxcomplete#tmux_pane_to_buffer()
         let g:tmuxcomplete_pane_index_display_duration_ms = "350"
     endif

--- a/plugin/tmuxcomplete.vim
+++ b/plugin/tmuxcomplete.vim
@@ -25,8 +25,10 @@ function! s:init()
       lua require'compe'.register_source('tmux', require'compe_tmux')
     endif
 
-    " for use with tmuxcomplete#tmux_pane_to_buffer()
-    let g:tmuxcomplete_pane_index_display_duration_ms = "350"
+    if exists('g:tmuxcomplete_pane_index_display_duration_ms')
+        " for use with tmuxcomplete#tmux_pane_to_buffer()
+        let g:tmuxcomplete_pane_index_display_duration_ms = "350"
+    endif
 
 endfunction
 

--- a/plugin/tmuxcomplete.vim
+++ b/plugin/tmuxcomplete.vim
@@ -24,6 +24,9 @@ function! s:init()
     if exists('g:loaded_compe')
       lua require'compe'.register_source('tmux', require'compe_tmux')
     endif
+
+    let g:tmuxcomplete_pane_index_display_duration_ms = "350"
+
 endfunction
 
 call s:init()

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -6,6 +6,10 @@
 # Words visible in current window, excluding current pane
 #     sh tmuxcomplete -e
 #
+# Words visible in specified pane in current window
+# (can't be used alongside the -e option)
+#     sh tmuxcomplete -t <pane_idex>
+#
 # Words visible in current session
 #     sh tmuxcomplete -l '-s'
 #
@@ -35,21 +39,23 @@ fi
 
 EXCLUDE='0'
 NOSORT='0'
+TARGET='-1'
 PATTERN=''
 SPLITMODE=words
 LISTARGS=''
 CAPTUREARGS=''
 GREPARGS=''
-while getopts enp:s:l:c:g: name
+while getopts enp:s:t:l:c:g: name
 do case $name in
     e) EXCLUDE="1";;
     n) NOSORT="1";; # internal/undocumented, don't use, might be changed in the future
+    t) TARGET="$OPTARG";;
     p) PATTERN="$OPTARG";;
     s) SPLITMODE="$OPTARG";;
     l) LISTARGS="$OPTARG";;
     c) CAPTUREARGS="$OPTARG";;
     g) GREPARGS="$OPTARG";;
-    *) echo "Usage: $0 [-p pattern] [-s splitmode] [-l listargs] [-c captureargs] [-g grepargs]\n"
+    *) echo "Usage: $0 [-t <pane_index>] [-p pattern] [-s splitmode] [-l listargs] [-c captureargs] [-g grepargs]\n"
         exit 2;;
 esac
 done
@@ -64,6 +70,9 @@ excludecurrent() {
         # echo 1>&2 'current' "$currentpane"
         # use -F to match $ in session id
         grep -v -F "$currentpane"
+    elif ! [ "$TARGET" = "-1" ]; then
+        targetpane=$(tmux display-message -p '01-#{session_id} ')$TARGET
+        grep -F "$targetpane"
     else
         cat
     fi

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -71,8 +71,7 @@ excludecurrent() {
         # use -F to match $ in session id
         grep -v -F "$currentpane"
     elif ! [ "$TARGET" = "-1" ]; then
-        targetpane=$(tmux display-message -p '01-#{session_id} ')$TARGET
-        grep -F "$targetpane"
+        echo $(tmux display-message -p '01-#{session_id} ')$TARGET
     else
         cat
     fi

--- a/sh/tmuxcomplete
+++ b/sh/tmuxcomplete
@@ -164,7 +164,7 @@ splitwords() {
 
 sortu() {
     if [ "$NOSORT" = "1" ]; then
-        uniq
+        cat
     else
         sort -u
     fi

--- a/tmuxcomplete
+++ b/tmuxcomplete
@@ -1,0 +1,185 @@
+#!/bin/sh
+
+# Usage: Get a list of all words visible in current window
+#     sh tmuxcomplete
+#
+# Words visible in current window, excluding current pane
+#     sh tmuxcomplete -e
+#
+# Words visible in specified pane in current window
+# (can't be used alongside the -e option)
+#     sh tmuxcomplete -t <pane_idex>
+#
+# Words visible in current session
+#     sh tmuxcomplete -l '-s'
+#
+# Words visible in all sessions
+#     sh tmuxcomplete -l '-a'
+#
+# Words containing 'foo'
+#     sh tmuxcomplete -p 'foo'
+#
+# List of lines
+#     sh tmuxcomplete -s lines
+#
+# Words containing 'foo', ignoring case
+#     sh tmuxcomplete -p 'foo' -g '-i'
+#
+# Words beginning with 'foo'
+#     sh tmuxcomplete -p '^foo'
+#
+# Words including 2000 lines of history per pane
+#     sh tmuxcomplete -c '-S -2000'
+
+if ! tmux info > /dev/null 2>&1; then
+    echo "[tmux-complete.vim]"
+    echo "No tmux found!"
+    exit 0
+fi
+
+EXCLUDE='0'
+NOSORT='0'
+TARGET='-1'
+PATTERN=''
+SPLITMODE=words
+LISTARGS=''
+CAPTUREARGS=''
+GREPARGS=''
+while getopts enp:s:t:l:c:g: name
+do case $name in
+    e) EXCLUDE="1";;
+    n) NOSORT="1";; # internal/undocumented, don't use, might be changed in the future
+    t) TARGET="$OPTARG";;
+    p) PATTERN="$OPTARG";;
+    s) SPLITMODE="$OPTARG";;
+    l) LISTARGS="$OPTARG";;
+    c) CAPTUREARGS="$OPTARG";;
+    g) GREPARGS="$OPTARG";;
+    *) echo "Usage: $0 [-t <pane_index>] [-p pattern] [-s splitmode] [-l listargs] [-c captureargs] [-g grepargs]\n"
+        exit 2;;
+esac
+done
+
+listpanes() {
+    tmux list-panes $LISTARGS -F '#{pane_active}#{window_active}-#{session_id} #{pane_id}'
+}
+
+excludecurrent() {
+    if [ "$EXCLUDE" = "1" ]; then
+        currentpane=$(tmux display-message -p '11-#{session_id} ')
+        # echo 1>&2 'current' "$currentpane"
+        # use -F to match $ in session id
+        grep -v -F "$currentpane"
+    elif ! [ "$TARGET" = "-1" ]; then
+        echo $(tmux display-message -p '01-#{session_id} ')$TARGET
+    else
+        cat
+    fi
+}
+
+paneids() {
+    cut -d' ' -f2
+}
+
+capturepanes() {
+    panes=$(cat)
+    if [ -z "$panes" ]; then
+        # echo 'no panes' 1>&2
+        return
+    elif tmux capture-pane -p >/dev/null 2>&1; then
+        # tmux capture-pane understands -p -> use it
+        echo "$panes" | xargs -n1 tmux capture-pane $CAPTUREARGS -p -t
+    else
+        # tmux capture-pane doesn't understand -p (like version 1.6)
+        # -> capture to paste-buffer, echo it, then delete it
+        echo "$panes" | xargs -n1 -I{} sh -c "tmux capture-pane $CAPTUREARGS -t {} && tmux show-buffer && tmux delete-buffer"
+    fi
+}
+
+split() {
+    if [ "$SPLITMODE" = "ilines,words" ]; then
+        # this is most reabable, but not posix compliant
+        # tee >(splitilines) >(splitwords)
+
+        # from https://unix.stackexchange.com/a/43536
+        # this has some issues with trailing whitespace sometimes
+        # tmp_dir=$(mktemp -d)
+        # mkfifo "$tmp_dir/f1" "$tmp_dir/f2"
+        # splitilines <"$tmp_dir/f1" & pid1=$!
+        # splitwords  <"$tmp_dir/f2" & pid2=$!
+        # tee "$tmp_dir/f1" "$tmp_dir/f2"
+        # rm -rf "$tmp_dir"
+        # wait $pid1 $pid2
+
+        splitilinesandwords
+    elif [ "$SPLITMODE" = "lines" ]; then
+        splitlines
+    elif [ "$SPLITMODE" = "ilines" ]; then
+        splitilines
+    elif [ "$SPLITMODE" = "words" ]; then
+        splitwords
+    fi
+}
+
+splitilinesandwords() {
+    # print full line to duplicate it
+    # on the duplicate substitute all spaces with newlines
+    # duplicate that result again
+    # in that duplicate replace all non word characters by linebreaks 
+    sed -e 'p;s/[[:space:]]\{1,\}/\
+        /g;p;s/[^a-zA-Z0-9_]\{1,\}/\
+        /g' |
+    # remove surrounding non-word characters
+    grep -o "\\w.*\\w"
+}
+
+splitlines() {
+    # remove surrounding whitespace
+    grep -o "\\S.*\\S"
+}
+
+splitilines() {
+    # starts at first word character
+    grep -o "\\w.*\\S"
+}
+
+# returns both WORDS and words of each given line
+splitwords() {
+    # use sed like this instead of tr?
+    # substitute all spaces with newlines
+    # duplicate that line
+    # in the duplicate replace all non word characters by linebreaks 
+    # sed -e 's/[[:space:]]\{1,\}/\
+    #     /g;p;s/[^a-zA-Z0-9_]/ /g;s/[[:space:]]\{1,\}/\
+    #     /g' |
+
+    # copy lines and split words
+    sed -e 'p;s/[^a-zA-Z0-9_]/ /g' |
+    # split on spaces
+    tr -s '[:space:]' '\n' |
+    # remove surrounding non-word characters
+    grep -o "\\w.*\\w"
+}
+
+sortu() {
+    if [ "$NOSORT" = "1" ]; then
+        cat
+    else
+        sort -u
+    fi
+}
+
+# list all panes
+listpanes |
+# filter out current pane
+excludecurrent |
+# take the pane id
+paneids |
+# capture panes
+capturepanes |
+# split words or lines depending on splitmode
+split |
+# filter out items not matching pattern
+grep -e "$PATTERN" $GREPARGS |
+# sort and remove duplicates
+sortu


### PR DESCRIPTION
This is my first pull request (following the new issue I created on 05/01/2022 requesting the feature), so I hope it's in good order. I explained the new feature in the updated README.md

At one point I accidentally overwrote the file sh/tmuxcomplete with an altered copy, so now it's showing that all the lines were changed. I actually only altered two functions and added a new option flag `-t` in the `getopts` loop. Below I just show the additional lines:

```sh
TARGET='-1'

while getopts enp:s:t:l:c:g: name
do case $name in

    t) TARGET="$OPTARG";;

    *) echo "Usage: $0 [-t <pane_index>] [-p pattern] [-s splitmode] [-l listargs] [-c captureargs] [-g grepargs]\n"
        exit 2;;
esac
done
```
and the two functions in they're entirety (the new part is the `elif`): 
```sh
excludecurrent() {
    if [ "$EXCLUDE" = "1" ]; then
        currentpane=$(tmux display-message -p '11-#{session_id} ')
        # echo 1>&2 'current' "$currentpane"
        # use -F to match $ in session id
        grep -v -F "$currentpane"
    elif ! [ "$TARGET" = "-1" ]; then
        echo $(tmux display-message -p '01-#{session_id} ')$TARGET
    else
        cat
    fi
}
```
and (the new part is that `uniq` is changed to `cat`:
```sh
sortu() {
    if [ "$NOSORT" = "1" ]; then
        cat
    else
        sort -u
    fi
}
```

Please let me know if this feature is of interest/within the scope of the plugin, and if there's anymore I should do.